### PR TITLE
Preserve stdout and stderr in xcrun

### DIFF
--- a/Libraries/plist/Sources/Format/Encoding.cpp
+++ b/Libraries/plist/Sources/Format/Encoding.cpp
@@ -10,6 +10,7 @@
 #include <plist/Format/unicode.h>
 
 #include <cassert>
+#include <cstdlib>
 
 #if defined(__linux__)
 #include <endian.h>


### PR DESCRIPTION
Previously, xcrun would merge stdout and stderr of the child process into its own stdout. This confuses tools such as Go's CGo, which rely on parsing the compiler's stderr.

@thii I confirmed that `rules_go` can compile targets using CGo with this change.